### PR TITLE
Fix NonCommandMessageFilter for messages without entities

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,7 +50,13 @@ def truncate(text, max_tokens):
 
 class NonCommandMessageFilter(filters.MessageFilter):
     def filter(self, message: filters.Message):
-        return not any(entity.type == filters.MessageEntity.BOT_COMMAND for entity in message.entities)
+        if not message.entities:
+            return True
+
+        return not any(
+            entity.type == filters.MessageEntity.BOT_COMMAND
+            for entity in message.entities
+        )
 
 class MentionFilter(filters.MessageFilter):
     def __init__(self, usernames: str):


### PR DESCRIPTION
## Summary
- avoid iterating over `None` in `NonCommandMessageFilter.filter`
- treat messages without entities as non-commands

## Testing
- `python -m py_compile main.py`
