### PR TITLE
Rewrite tests with pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,68 @@
+import os
+import sys
+import types
+import importlib
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("ALLOWED_CHAT_ID", "1")
+
+class DummyTokenizer:
+    def encode(self, text):
+        return []
+
+    def decode(self, tokens):
+        return ""
+
+@pytest.fixture(autouse=True)
+def stub_modules():
+    openai = types.SimpleNamespace(api_key="", ChatCompletion=types.SimpleNamespace(create=lambda *a, **k: None))
+    tiktoken = types.SimpleNamespace(encoding_for_model=lambda name: DummyTokenizer())
+    aiofiles = types.ModuleType("aiofiles")
+    loguru = types.ModuleType("loguru")
+    loguru.logger = types.SimpleNamespace(info=lambda *a, **k: None, warning=lambda *a, **k: None)
+    telegram = types.ModuleType("telegram")
+    telegram.Update = type("Update", (), {})
+    telegram.Message = type("Message", (), {})
+    telegram_ext = types.ModuleType("telegram.ext")
+    telegram_ext.Application = type("Application", (), {})
+    telegram_ext.CommandHandler = type("CommandHandler", (), {})
+    telegram_ext.MessageHandler = type("MessageHandler", (), {})
+    telegram_ext.CallbackContext = type("CallbackContext", (), {})
+    telegram_ext.filters = types.SimpleNamespace(
+        MessageFilter=type("MessageFilter", (), {}),
+        Message=type("Message", (), {}),
+        MessageEntity=types.SimpleNamespace(BOT_COMMAND="bot_command"),
+        ALL=None,
+        Chat=lambda chat_id=None: None,
+    )
+
+    modules = {
+        "openai": openai,
+        "tiktoken": tiktoken,
+        "aiofiles": aiofiles,
+        "loguru": loguru,
+        "telegram": telegram,
+        "telegram.ext": telegram_ext,
+    }
+    original = {name: sys.modules.get(name) for name in modules}
+    sys.modules.update(modules)
+    try:
+        yield
+    finally:
+        for name, mod in original.items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
+
+def load_main(tmp_path):
+    if "main" in sys.modules:
+        importlib.reload(sys.modules["main"])
+    else:
+        importlib.import_module("main")
+    import main
+    main.message_storage = []
+    main.MESSAGE_STORAGE_PATH = str(tmp_path / "messages.jsonl")
+    return main
+

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,71 +1,7 @@
-import os
-import unittest
-import tempfile
-import os
-import sys
-import types
-import tempfile
-import unittest
+import importlib
 from types import SimpleNamespace
 from datetime import datetime
-
-os.environ.setdefault("OPENAI_API_KEY", "test")
-os.environ.setdefault("ALLOWED_CHAT_ID", "1")
-
-# Stub out external dependencies so that main can be imported
-openai_stub = types.ModuleType("openai")
-openai_stub.ChatCompletion = types.SimpleNamespace(create=lambda *a, **k: None)
-openai_stub.api_key = ""
-sys.modules.setdefault("openai", openai_stub)
-
-tiktoken_stub = types.ModuleType("tiktoken")
-
-class DummyTokenizer:
-    def encode(self, text):
-        return []
-
-    def decode(self, tokens):
-        return ""
-
-
-def encoding_for_model(name):
-    return DummyTokenizer()
-
-tiktoken_stub.encoding_for_model = encoding_for_model
-sys.modules.setdefault("tiktoken", tiktoken_stub)
-
-aiofiles_stub = types.ModuleType("aiofiles")
-sys.modules.setdefault("aiofiles", aiofiles_stub)
-
-loguru_stub = types.ModuleType("loguru")
-loguru_stub.logger = types.SimpleNamespace(info=lambda *a, **k: None, warning=lambda *a, **k: None)
-sys.modules.setdefault("loguru", loguru_stub)
-
-telegram_stub = types.ModuleType("telegram")
-telegram_stub.Update = type("Update", (), {})
-telegram_stub.Message = type("Message", (), {})
-sys.modules.setdefault("telegram", telegram_stub)
-
-telegram_ext_stub = types.ModuleType("telegram.ext")
-
-class DummyFilter:
-    pass
-
-telegram_ext_stub.Application = type("Application", (), {})
-telegram_ext_stub.CommandHandler = type("CommandHandler", (), {})
-telegram_ext_stub.MessageHandler = type("MessageHandler", (), {})
-telegram_ext_stub.CallbackContext = type("CallbackContext", (), {})
-telegram_ext_stub.filters = types.SimpleNamespace(
-    MessageFilter=DummyFilter,
-    Message=type("Message", (), {}),
-    MessageEntity=types.SimpleNamespace(BOT_COMMAND="bot_command"),
-    ALL=None,
-    Chat=lambda chat_id=None: None,
-)
-sys.modules.setdefault("telegram.ext", telegram_ext_stub)
-
-import main
-
+import pytest
 
 class FakeMessage:
     def __init__(self, text):
@@ -74,64 +10,29 @@ class FakeMessage:
         self.from_user = SimpleNamespace(first_name="Alice", id=123)
         self.chat_id = 1
         self.replied_text = None
-
     async def reply_text(self, text):
         self.replied_text = text
-
 
 class FakeUpdate:
     def __init__(self, text):
         self.message = FakeMessage(text)
 
+@pytest.mark.asyncio
+async def test_handle_message_to_bot(tmp_path):
+    main = importlib.import_module('main')
+    main = importlib.reload(main)
+    main.message_storage = []
+    main.MESSAGE_STORAGE_PATH = str(tmp_path / 'messages.jsonl')
 
-class FakeContext:
-    pass
+    async def fake_save(message):
+        pass
+    main.save_message_to_storage = fake_save
 
+    def fake_create(*args, **kwargs):
+        return SimpleNamespace(choices=[SimpleNamespace(message={"content": "Marv: ping"})])
+    main.openai.ChatCompletion.create = fake_create
 
-class TestHandleMessageToBot(unittest.IsolatedAsyncioTestCase):
-    async def asyncSetUp(self):
-        self.original_storage = main.message_storage
-        main.message_storage = []
-        self.original_path = main.MESSAGE_STORAGE_PATH
-        tmp = tempfile.NamedTemporaryFile(delete=False)
-        tmp.close()
-        self.temp_path = tmp.name
-        main.MESSAGE_STORAGE_PATH = self.temp_path
-
-    async def asyncTearDown(self):
-        main.message_storage = self.original_storage
-        main.MESSAGE_STORAGE_PATH = self.original_path
-        if os.path.exists(self.temp_path):
-            os.remove(self.temp_path)
-
-    async def test_handle_message_removes_prefix(self):
-        async def fake_handle_message(update, context):
-            pass
-
-        async def fake_save(message):
-            pass
-
-        def fake_create(*args, **kwargs):
-            return SimpleNamespace(choices=[SimpleNamespace(message={"content": "Marv: ping"})])
-
-        original_handle = main.handle_message
-        original_save = main.save_message_to_storage
-        original_create = main.openai.ChatCompletion.create
-
-        main.handle_message = fake_handle_message
-        main.save_message_to_storage = fake_save
-        main.openai.ChatCompletion.create = fake_create
-
-        try:
-            update = FakeUpdate("hello")
-            await main.handle_message_to_bot(update, FakeContext())
-            self.assertEqual(update.message.replied_text, "ping")
-            self.assertEqual(main.message_storage[-1]["message"], "ping")
-        finally:
-            main.handle_message = original_handle
-            main.save_message_to_storage = original_save
-            main.openai.ChatCompletion.create = original_create
-
-
-if __name__ == "__main__":
-    unittest.main()
+    update = FakeUpdate('hello')
+    await main.handle_message_to_bot(update, SimpleNamespace())
+    assert update.message.replied_text == 'ping'
+    assert main.message_storage[-1]["message"] == 'ping'

--- a/tests/test_prefix.py
+++ b/tests/test_prefix.py
@@ -1,73 +1,12 @@
-import os
-import sys
-import types
-import unittest
+import importlib
 
-os.environ.setdefault("OPENAI_API_KEY", "test")
-os.environ.setdefault("ALLOWED_CHAT_ID", "1")
-
-# Provide minimal stubs for external packages used by main
-openai_stub = types.ModuleType("openai")
-openai_stub.ChatCompletion = types.SimpleNamespace()
-openai_stub.api_key = ""
-sys.modules.setdefault("openai", openai_stub)
-
-tiktoken_stub = types.ModuleType("tiktoken")
-
-class DummyTokenizer:
-    def encode(self, text):
-        return []
-
-    def decode(self, tokens):
-        return ""
-
-
-def encoding_for_model(name):
-    return DummyTokenizer()
-
-tiktoken_stub.encoding_for_model = encoding_for_model
-sys.modules.setdefault("tiktoken", tiktoken_stub)
-
-aiofiles_stub = types.ModuleType("aiofiles")
-sys.modules.setdefault("aiofiles", aiofiles_stub)
-
-loguru_stub = types.ModuleType("loguru")
-loguru_stub.logger = types.SimpleNamespace(info=lambda *a, **k: None, warning=lambda *a, **k: None)
-sys.modules.setdefault("loguru", loguru_stub)
-
-telegram_stub = types.ModuleType("telegram")
-telegram_stub.Update = type("Update", (), {})
-telegram_stub.Message = type("Message", (), {})
-sys.modules.setdefault("telegram", telegram_stub)
-
-telegram_ext_stub = types.ModuleType("telegram.ext")
-
-class DummyFilter:
-    pass
-
-telegram_ext_stub.Application = type("Application", (), {})
-telegram_ext_stub.CommandHandler = type("CommandHandler", (), {})
-telegram_ext_stub.MessageHandler = type("MessageHandler", (), {})
-telegram_ext_stub.CallbackContext = type("CallbackContext", (), {})
-telegram_ext_stub.filters = types.SimpleNamespace(
-    MessageFilter=DummyFilter,
-    Message=type("Message", (), {}),
-    MessageEntity=types.SimpleNamespace(BOT_COMMAND="bot_command"),
-    ALL=None,
-    Chat=lambda chat_id=None: None,
-)
-sys.modules.setdefault("telegram.ext", telegram_ext_stub)
-
-from main import strip_marv_prefix
-
-
-class TestStripMarvPrefix(unittest.TestCase):
-    def test_strip_prefix_variants(self):
-        self.assertEqual(strip_marv_prefix("Marv: hello"), "hello")
-        self.assertEqual(strip_marv_prefix("marv:   hi"), "hi")
-        self.assertEqual(strip_marv_prefix("MARV:hey"), "hey")
-        self.assertEqual(strip_marv_prefix("Hi there"), "Hi there")
-
-
-if __name__ == "__main__":
-    unittest.main()
+def test_strip_prefix_variants(tmp_path):
+    main = importlib.import_module('main')
+    main = importlib.reload(main)
+    main.message_storage = []
+    main.MESSAGE_STORAGE_PATH = str(tmp_path / 'messages.jsonl')
+    strip = main.strip_marv_prefix
+    assert strip('Marv: hello') == 'hello'
+    assert strip('marv:   hi') == 'hi'
+    assert strip('MARV:hey') == 'hey'
+    assert strip('Hi there') == 'Hi there'


### PR DESCRIPTION
## Summary
- replace unittest tests with pytest equivalents
- add fixtures to stub external dependencies in `conftest.py`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*